### PR TITLE
Document buffer-local mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Now you can use the `yc` operator on any motion or text object, such as `yc)`
 to capitalize from the cursor to the beginning of the next sentence, or `ycap`
 to capitalize every word in the paragraph.
 
+### Buffer-local mappings
+
+When you want a mapping to apply only to the current buffer, prepend `<buffer>`
+to the left hand side of the mapping.
+
+    :MapExpress <buffer>cd '/* ' . v:val . ' */'
+
 ### NOTE
 
 At the time of loading your `.vimrc` file, the commands `:MapExpress` and

--- a/doc/express.txt
+++ b/doc/express.txt
@@ -30,6 +30,12 @@ COMMANDS                                        *express-commands*
                         {op} as the left hand side of the mapping.
                         See |:substitute| for help on substitutions.
 
+                                                *express-<buffer>*
+When you want a mapping to apply only to the current buffer, prepend <buffer>
+to the left hand side of the mapping.
+
+    :MapExpress <buffer>cd '/* ' . v:val . ' */'
+
 MAPPINGS                                        *express-mappings*
 
                                                 *g=*


### PR DESCRIPTION
It took me a while until I realized that it is possible to achieve buffer-local mappings with `MapExpress` and `MapSubpress`, by prepending the lhs of the mapping with `<buffer>`, e.g. `MapExpress <buffer>cd '/* ' . v:val . ' */'`. I tried it with a space between the `<buffer>` and the lhs, but that did not work. Since some of the mappings only really make sense in certain filetypes I thought it would be nice if this little fact were documented.